### PR TITLE
chore(netlify): upgrade Node.js runtime version to 22

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
   functions = "netlify/functions"
 
 [build.environment]
-  NODE_VERSION = "18"
+  NODE_VERSION = "22"
 
 [functions]
   node_bundler = "esbuild"


### PR DESCRIPTION
- Update NODE_VERSION from 18 to 22 in Netlify build configuration
- Ensures compatibility with latest Node.js LTS and modern JavaScript features
- Improves build performance and security with newer runtime